### PR TITLE
FIX: move test registration into #ifdef

### DIFF
--- a/src/tests/unit_asio_stream.cpp
+++ b/src/tests/unit_asio_stream.cpp
@@ -537,7 +537,8 @@ class ASIO_Stream_Tests final : public Test
          }
    };
 
+BOTAN_REGISTER_TEST("asio_stream", ASIO_Stream_Tests);
+
 #endif
 
-BOTAN_REGISTER_TEST("asio_stream", ASIO_Stream_Tests);
 }  // namespace Botan_Tests


### PR DESCRIPTION
... otherwise it doesn't compile without `BOTAN_HAS_BOOST_ASIO`.